### PR TITLE
fix: Only ratchet up to goal

### DIFF
--- a/src/updatePerFileCoverageExceptions.js
+++ b/src/updatePerFileCoverageExceptions.js
@@ -52,7 +52,7 @@ exports.updatePerFileCoverageExceptions =
         if (coverageIgnore.some(ignoreGlob => minimatch(file, ignoreGlob))) {
           // Skip ignored file.
         } else if (coverageLessThan(coverage, config.coverageGoal)) {
-          exceptions[file] = coverageException(coverage);
+          exceptions[file] = coverageException(coverage, config.coverageGoal);
         }
 
         return exceptions;
@@ -70,10 +70,10 @@ exports.updatePerFileCoverageExceptions =
       JSON.stringify(allExceptions, undefined, 2),
     );
 
-    function coverageException(current) {
+    function coverageException(current, goal) {
       return Object.entries(current).reduce(
         (accumulator, [key, { pct: percent }]) => {
-          accumulator[key] = percent;
+          accumulator[key] = Math.min(percent, goal[key]);
           return accumulator;
         },
         {},


### PR DESCRIPTION
If coverage is higher than the goal, don't enforce that it stays at that level, use the goal as the point of enforcement. This means you can actually slip from some value higher than the goal to another value still higher than the goal, with no complaints. This is acceptable, because both values are still higher than the goal. #philosophy