### PR TITLE
feat: Update merge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Additionally, this library can be added to an existing project such that legacy 
 - supports JavaScript and TypeScript projects
 - prevents coverage from slipping, even on legacy files
 - detects coverage improvements and prints messaging to update snapshots
-- CI friendly; updating snapshots is a separate explicit activity
+- designed for CI; updating snapshots is a separate explicit activity
 - supports monitoring completely untested code through dynamic usage of `collectCoverageFrom`
+- supports coverage merging for usage with parallelized testing
 
 ## Requirements
 
@@ -24,8 +25,8 @@ Additionally, this library can be added to an existing project such that legacy 
 ## Configure Jest
 
 Within `jest.config.js` or `jest.config.ts`:
-1. Ensure Jest is configured to include `json-summary` in `coverageReporters`.
-1. Ensure that coverage collection is enabled, either with the `--coverage` parameter, or by configuring `collectCoverage` to `true`.
+1. Ensure Jest is configured to include `json` in `coverageReporters`.
+1. Ensure that coverage collection is enabled in the CI command (e.g. with the `--coverage` parameter).
 1. Either remove the `coverageThreshold` configuration from Jest, or set it to: `coverageThreshold: { global: {} }`.
 1. Wrap the configuration with the `withJestSlipDetection` utility method in order to dynamically leverage `collectCoverageFrom` set to the configured `coverageGlob`.
 
@@ -36,9 +37,8 @@ const { withJestSlipDetection } = require("@jobber/jest-a-coverage-slip-detector
 
 module.exports = withJestSlipDetection({
   coverageReporters: [
-    "json-summary" // plus any other reporters, e.g. "lcov", "text", "text-summary"
+    "json" // plus any other reporters, e.g. "lcov", "text", "text-summary"
   ],
-  collectCoverage: true,
   coverageThreshold: { global: {} },
 });
 ```
@@ -51,9 +51,8 @@ import { withJestSlipDetection } from "@jobber/jest-a-coverage-slip-detector";
 
 const config: Config.InitialOptions = {
   coverageReporters: [
-    "json-summary" // plus any other reporters, e.g. "lcov", "text", "text-summary"
+    "json" // plus any other reporters, e.g. "lcov", "text", "text-summary"
   ],
-  collectCoverage: true,
   transform: {
     "^.+\\.ts?$": "ts-jest",
   }
@@ -64,14 +63,22 @@ export default withJestSlipDetection(config);
 
 ## Configure Scripts
 
+These scripts assume you have the following two reporters installed:
+```
+npm i -D jest-progress-bar-reporter jest-junit
+```
+
 Within `package.json`:
 ```js
 {
   "scripts": {
-    "test": "jest --coverage", // or set `collectCoverage` to `true` in Jest config
-    "posttest": "jest-a-coverage-slip-detector",
+    "test": "jest",
+    "test:ci": "jest --runInBand --coverage --reporters=jest-progress-bar-reporter --reporters=jest-junit --ci",
+    "posttest:ci": "npm run test:validateCoverage",
+    "test:generateCoverage": "jest --coverage --reporters=jest-progress-bar-reporter --ci",
+    "test:validateCoverage": "jest-a-coverage-slip-detector",
     "test:updateCoverageExceptions": "jest-a-coverage-slip-detector --update", // Used to 'ratchet' up coverage after improving it.
-    "test:updateCoverageExceptionsForce": "jest-a-coverage-slip-detector --force-update" // Used to set the initial per file snapshot or to force accept a reduction in coverage.
+    "test:setCoverageExceptionsBaseline": "jest-a-coverage-slip-detector --force-update" // Sets the baseline for test coverage (accepts any under-target coverage).
   }
 }
 ```
@@ -107,44 +114,46 @@ Example:
 
 ### First Run
 
-1. Generate and view coverage errors: `npm test`
-1. Snapshot current coverage errors as legacy exceptions: `npm run test:updateCoverageExceptionsForce`
+1. Generate and view coverage errors: `npm run test:generateCoverage && npm run test:validateCoverage`
+1. Snapshot current coverage errors as legacy exceptions: `npm run test:setCoverageExceptionsBaseline`
 1. Commit the generated exception listing (`generatedCoverageExceptions.json` by default) to source control
+1. Use `npm run test:ci` in your CI (the key things are that coverage is enabled and that the `--ci` argument is present)
 
 ### Going Forward
 
-- Run `npm test` as normal (locally or in CI), any slips in test coverage will fail out the command. Note that this will happen for either legacy files not meeting their recorded targets, or in new files not meeting the configured goals.
+- Any slips in test coverage will fail out the CI command. Note that this will happen for either legacy files not meeting their recorded targets, or in new files not meeting the configured goals.
+- Any improvements in test coverage will also fail out the CI command with a prompt to run `npm run test:generateCoverage && npm run test:updateCoverageExceptions` and commit the updated exception listing to "ratchet" up the coverage.
 - If you want to soft-launch the tooling, use the `--report-only` option in the initial rollout, and remove the option once you're ready to require coverage errors to be addressed.
-- As improvements to test coverage are made to legacy files, run `npm run test:updateCoverageExceptions` to update the exception listing (and commit it) to "ratchet" up the coverage.
 
 ## Concurrency and Parallelism
 
-If you're leveraging parallelism to do test splitting and running your tests concurrently on CI (e.g. fan-out/fan-in), a few adjustments to the pattern are needed. Collecting coverage while testing and reporting using `postpost` will result in reporting happening multiple times on each concurrent test run, potentially against incomplete coverage numbers.
-
-If parallelism is being used:
-1. Collect full `json` coverage reports - this will happen automatically if you configure a `mergeCoveragePath` and use `--ci` in your CI's test command.
-    - You will need to configure your CI to collect these in such a way that they can be located later using the path configured in `mergeCoveragePath`. For CircleCI, this means adding them to a workspace folder with unique names.
-1. Ensure you aren't triggering `posttest` in your CI - this means using jest directly in a CI specific test command and avoiding calling `npm test` in CI.
-1. Setup an additional job in the CI (e.g. `test_coverage`) that runs after the concurrent testing is completed.
-    - Explicitly run posttest with the merge argument: `npm run posttest -- --merge`.
+If you're leveraging parallelism to do test splitting and running your tests concurrently on CI (e.g. fan-out/fan-in), a few adjustments to the pattern are needed.
 
 <img src="https://circleci.com/docs/assets/img/docs/fan-out-in.png" width="300">
 
+1. Remove the `posttest:ci` script - you'll need to explicitly invoke coverage validation as a separate step after you gather coverage on the concurrent runs.
 
-Example `package.json` script:
+Use `jest` to generate the files to be tested so you ensure you have parity with the test run and coverage gathering used to generate the exceptions:
 ```js
-{
-  "scripts": {
-    "test:ci": "jest --coverage --runInBand --reporters=default --reporters=jest-junit --ci", // don't trigger posttest
-  }
-}
+TESTFILES=$(npx jest --listTests | sed s:$PWD/:: | circleci tests split --split-by=timings --show-counts)
+npm run test:ci $TESTFILES
 ```
+
+2. You will need to configure your CI to keep the full `json` coverage reports around for a follow-up validation step in your workflow. Ensure these can be located later using the path configured in `mergeCoveragePath`. For CircleCI, this means adding them to a workspace folder with unique names:
+```js
+// example
+COVERAGE_REPORT_SHARD=final-coverage-files/coverage-final${CIRCLE_NODE_INDEX}.json
+npm run test:ci $TESTFILES && mv coverage/coverage-final.json $COVERAGE_REPORT_SHARD
+```
+
+3. Setup an additional job in the CI (e.g. `test_coverage`) that runs after the concurrent testing is completed.
+    - Explicitly run `test:validateCoverage` with the `merge` argument: `npm run test:validateCoverage -- --merge`.
 
 Example `config.json`:
 ```js
 {
   ...
-  "mergeCoveragePath": "workspace/final-coverage-files",
+  "mergeCoveragePath": "final-coverage-files",
   ...
 }
 ```
@@ -175,20 +184,24 @@ Options:
 
 *After I'm setup with this library, what if I decide to raise the coverage goal higher for new code?*
 
-- No problem! Just set the goal higher in the project's `jest-a-coverage-slip-detector/config.json` file and then update snapshots using `npm run test:updateCoverageExceptionsForce`.
+- No problem! Just set the goal higher in the project's `jest-a-coverage-slip-detector/config.json` file and then update snapshots using `npm run test:setCoverageExceptionsBaseline`.
 
 *Do I need to use different test commands on dev than I would on CI?*
 
-- No. In both cases, coverage will run and you will get failures on slippages and messaging if improvements are detected.
+- Yes, you should. CI test commands for Jest are intended to include `--runInBand` and `--ci` on CI.
 
-*What if I just want to test a specific file, will I incur a full coverage scan?*
+*Why do I only see the coverage errors on CI and not locally?*
 
-- No. If a test path pattern is detected (e.g. `npm test tests/foo.test.ts`) coverage will only be calculated for the code under test.
+- It takes a full test run to get reliable coverage numbers to use for checking for slippages or messaging if improvements are detected. For example, if you run Jest against a single file then the calculated coverage for other files will report incorrectly even if they do have tests that just weren't executed by this focused run. However, if your tests run fast enough and you are accustomed to running the full suite locally, feel free to run `npm run test:validateCoverage` (e.g. perhaps via a `posttest` script).
+
+*What if I'm running tests locally, will I be slowed down by coverage scanning?*
+
+- No. Code coverage is only expected to be enabled on CI (although feel free to enable it locally for other use cases!).
 
 *How do I incrementally add test coverage to a previously uncovered file without having testing fail due to the goal being unmet?*
 
-- This library dynamically leverages `collectCoverageFrom` in order to capture snapshots on files even if they are completely untested. This means that as you incrementally add test coverage, instead of a failure, you'll be greeted with a message celebrating the improved coverage and recommending that you update snapshots to bump up the threshold for that file.
+- This library dynamically leverages `collectCoverageFrom` in order to capture snapshots on files even if they are completely untested. This means that as you incrementally add test coverage, you'll be greeted with a message in the CI failure celebrating the improved coverage and asking that you update snapshots to bump up the threshold for that file.
 
 *What exactly is the purpose of `withJestSlipDetection`?*
 
-- In order to properly ensure coverage reporting at a per file level we need to collect coverage from every file. If you run Jest against a single file then the calculated coverage for other files will report incorrectly even if they do have tests that just weren't executed by this focused run. To guard against this `withJestSlipDetection` will intelligently set Jest's internal `collectCoverageFrom`.
+- In order to properly gather coverage reporting at a per file level we need to collect coverage from every file. To guard against this `withJestSlipDetection` will intelligently set Jest's internal `collectCoverageFrom`. This mechanism also allows some validation of key Jest configuration to be performed, to help identify misconfigurations that would impact this tooling.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Within `package.json`:
   "scripts": {
     "test": "jest --coverage", // or set `collectCoverage` to `true` in Jest config
     "posttest": "jest-a-coverage-slip-detector",
-    "jest:updateCoverageExceptions": "jest-a-coverage-slip-detector --update", // Used to 'ratchet' up coverage after improving it.
-    "jest:updateCoverageExceptionsForce": "jest-a-coverage-slip-detector --force-update" // Used to set the initial per file snapshot or to force accept a reduction in coverage.
+    "test:updateCoverageExceptions": "jest-a-coverage-slip-detector --update", // Used to 'ratchet' up coverage after improving it.
+    "test:updateCoverageExceptionsForce": "jest-a-coverage-slip-detector --force-update" // Used to set the initial per file snapshot or to force accept a reduction in coverage.
   }
 }
 ```
@@ -108,14 +108,14 @@ Example:
 ### First Run
 
 1. Generate and view coverage errors: `npm test`
-1. Snapshot current coverage errors as legacy exceptions: `npm run jest:updateCoverageExceptionsForce`
+1. Snapshot current coverage errors as legacy exceptions: `npm run test:updateCoverageExceptionsForce`
 1. Commit the generated exception listing (`generatedCoverageExceptions.json` by default) to source control
 
 ### Going Forward
 
 - Run `npm test` as normal (locally or in CI), any slips in test coverage will fail out the command. Note that this will happen for either legacy files not meeting their recorded targets, or in new files not meeting the configured goals.
 - If you want to soft-launch the tooling, use the `--report-only` option in the initial rollout, and remove the option once you're ready to require coverage errors to be addressed.
-- As improvements to test coverage are made to legacy files, run `npm run jest:updateCoverageExceptions` to update the exception listing (and commit it) to "ratchet" up the coverage.
+- As improvements to test coverage are made to legacy files, run `npm run test:updateCoverageExceptions` to update the exception listing (and commit it) to "ratchet" up the coverage.
 
 ## Concurrency and Parallelism
 
@@ -175,7 +175,7 @@ Options:
 
 *After I'm setup with this library, what if I decide to raise the coverage goal higher for new code?*
 
-- No problem! Just set the goal higher in the project's `jest-a-coverage-slip-detector/config.json` file and then update snapshots using `npm run jest:updateCoverageExceptionsForce`.
+- No problem! Just set the goal higher in the project's `jest-a-coverage-slip-detector/config.json` file and then update snapshots using `npm run test:updateCoverageExceptionsForce`.
 
 *Do I need to use different test commands on dev than I would on CI?*
 

--- a/bin/jest-a-coverage-slip-detector
+++ b/bin/jest-a-coverage-slip-detector
@@ -9,6 +9,7 @@ const {
 } = require("../src/mergeCoverage");
 
 let validateCoverage = false;
+let mergePerformed = false;
 const option = process.argv[2];
 switch (option) {
   case "--help":
@@ -43,6 +44,7 @@ Options:
   case "--merge":
     mergeCoverageAndGenerateSummaryReport();
     validateCoverage = true;
+    mergePerformed = true;
     break;
   default:
     validateCoverage = true;
@@ -50,7 +52,7 @@ Options:
 }
 
 if (validateCoverage) {
-  if (runPerFileCoverageTest() && option !== "--report-only") {
+  if (runPerFileCoverageTest(mergePerformed) && option !== "--report-only") {
     process.exit(1);
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,7 @@ const defaultConfig = {
   input: {
     coverageSummaryPath: "coverage/coverage-summary.json",
     coverageIgnorePath: "coverageIgnore.json",
+    alwaysMerge: true,
   },
   output: {
     generatedCoverageExceptionsPath: "generatedCoverageExceptions.json",

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,7 @@ const defaultConfig = {
     regeneratePrompt: `After a complete and passing ${chalk.yellow(
       "`npm test`",
     )} use ${chalk.yellow(
-      "`npm run jest:updateCoverageExceptions`",
+      "`npm run test:updateCoverageExceptions`",
     )} to regenerate the required test threshold for these files.`,
   },
 };

--- a/src/config.js
+++ b/src/config.js
@@ -30,16 +30,16 @@ const defaultConfig = {
   },
   messages: {
     belowThreshold:
-      "The following files are below their required test coverage threshold. Raise them before updating exceptions.",
+      "The following files are below the test coverage goals. Add more coverage!",
     belowLegacyThreshold:
-      "Some legacy files have a lower inherited coverage threshold. Raise coverage in these files to at least this level.",
+      "Note that some of these files only need to be brought up to their legacy thresholds (see the Goal column) - although feel free to bring them up beyond that.",
     aboveThreshold:
-      "The following files are above their inherited test coverage threshold. These exceptions should be updated to meet their new level.",
+      "Congratulations! The test coverage in the following files has been improved, let's lock in the updated thresholds.",
     regeneratePrompt: `After a complete and passing ${chalk.yellow(
-      "`npm test`",
+      "`npm run test:generateCoverage`,",
     )} use ${chalk.yellow(
       "`npm run test:updateCoverageExceptions`",
-    )} to regenerate the required test threshold for these files.`,
+    )} to update the coverage threshold for these files.`,
   },
 };
 

--- a/src/runPerFileCoverageTest.js
+++ b/src/runPerFileCoverageTest.js
@@ -3,10 +3,16 @@ const {
   perFileCoverageReport,
   logViolations,
 } = require("./coverageUtilities");
+const { mergeCoverageAndGenerateSummaryReport } = require("./mergeCoverage");
 const { loadConfig } = require("./config");
 
-exports.runPerFileCoverageTest = function runPerFileCoverageTest() {
+exports.runPerFileCoverageTest = function runPerFileCoverageTest(
+  mergePerformed = false,
+) {
   const config = loadConfig();
+  if (config.input.alwaysMerge && !mergePerformed) {
+    mergeCoverageAndGenerateSummaryReport();
+  }
 
   const { coverageSummary, coverageExceptions, coverageIgnore } =
     fromCoverageFiles();

--- a/src/updatePerFileCoverageExceptions.js
+++ b/src/updatePerFileCoverageExceptions.js
@@ -8,6 +8,7 @@ const {
   logViolations,
   coverageLessThan,
 } = require("./coverageUtilities");
+const { mergeCoverageAndGenerateSummaryReport } = require("./mergeCoverage");
 
 function ensurePathExists(filePath) {
   const dir = path.dirname(filePath);
@@ -19,6 +20,10 @@ function ensurePathExists(filePath) {
 exports.updatePerFileCoverageExceptions =
   function updatePerFileCoverageExceptions(forceUpdate = false) {
     const config = loadConfig();
+    if (config.input.alwaysMerge) {
+      mergeCoverageAndGenerateSummaryReport();
+    }
+
     const { writeFileSync } = require("fs");
 
     const { coverageSummary, coverageExceptions, coverageIgnore } =


### PR DESCRIPTION
The test coverage generated by istanbul in v2 gets "corrected" if you use v3 to merge it together to create a summary. It's not clear to me yet why jest isn't creating already-correct test coverage output even when using v3 transitive dependencies of istanbul (is this a bug? is it due to using a slightly older version of jest?), but the workaround is to merge it with itself even when not using concurrency.

This PR adds that merge approach, and also cleans up the documentation around the focusing this tool's use case to just be intended for CI.