### PR TITLE
fix: changed imports

### DIFF
--- a/src/runPerFileCoverageTest.js
+++ b/src/runPerFileCoverageTest.js
@@ -3,7 +3,7 @@ const {
   perFileCoverageReport,
   logViolations,
 } = require("./coverageUtilities");
-const { mergeCoverageAndGenerateSummaryReport } = require("./mergeCoverage");
+const { mergeCoverageAndGenerateReports } = require("./mergeCoverage");
 const { loadConfig } = require("./config");
 
 exports.runPerFileCoverageTest = function runPerFileCoverageTest(
@@ -11,7 +11,7 @@ exports.runPerFileCoverageTest = function runPerFileCoverageTest(
 ) {
   const config = loadConfig();
   if (config.input.alwaysMerge && !mergePerformed) {
-    mergeCoverageAndGenerateSummaryReport();
+    mergeCoverageAndGenerateReports();
   }
 
   const { coverageSummary, coverageExceptions, coverageIgnore } =

--- a/src/updatePerFileCoverageExceptions.js
+++ b/src/updatePerFileCoverageExceptions.js
@@ -8,7 +8,7 @@ const {
   logViolations,
   coverageLessThan,
 } = require("./coverageUtilities");
-const { mergeCoverageAndGenerateSummaryReport } = require("./mergeCoverage");
+const { mergeCoverageAndGenerateReports } = require("./mergeCoverage");
 
 function ensurePathExists(filePath) {
   const dir = path.dirname(filePath);
@@ -21,7 +21,7 @@ exports.updatePerFileCoverageExceptions =
   function updatePerFileCoverageExceptions(forceUpdate = false) {
     const config = loadConfig();
     if (config.input.alwaysMerge) {
-      mergeCoverageAndGenerateSummaryReport();
+      mergeCoverageAndGenerateReports();
     }
 
     const { writeFileSync } = require("fs");


### PR DESCRIPTION
A previous change neglected some imports. This PR fixes that.

## QA

- I ran both `jest-a-coverage-slip-detector --report-only` and `jest-a-coverage-slip-detector --update` and verified that the tool was operating as expected.