### PR TITLE
feat: Add config message for adding a documentation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Options:
   --report-only          Exit successfully even if coverage errors are detected.
 ```
 
+## Testing locally
+- Run `npm:install` in this repo to ensure everything is up-to-date
+- Run `npm:link` to register the package locally
+- In the repo consuming this package, run `npm link @jobber/jest-a-coverage-slip-detector`
+- Run `jest-a-coverage-slip-detector` - it will run this repo's code directly!
+
 ## FAQ
 
 *After I'm setup with this library, what if I decide to raise the coverage goal higher for new code?*

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Options:
 ```
 
 ## Testing locally
-- Run `npm:install` in this repo to ensure everything is up-to-date
+- Run `npm install` in this repo to ensure everything is up-to-date
 - Run `npm:link` to register the package locally
 - In the repo consuming this package, run `npm link @jobber/jest-a-coverage-slip-detector`
 - Run `jest-a-coverage-slip-detector` - it will run this repo's code directly!

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Options:
 
 ## Testing locally
 - Run `npm install` in this repo to ensure everything is up-to-date
-- Run `npm:link` to register the package locally
+- Run `npm link` to register the package locally
 - In the repo consuming this package, run `npm link @jobber/jest-a-coverage-slip-detector`
 - Run `jest-a-coverage-slip-detector` - it will run this repo's code directly!
 

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,8 @@ const defaultConfig = {
     )} use ${chalk.yellow(
       "`npm run test:updateCoverageExceptions`",
     )} to update the coverage threshold for these files.`,
+    // Override this message with a custom documentation prompt.
+    documentationPrompt: undefined,
   },
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ const defaultConfig = {
     additionalReports: {
       html: "coverage/html-report",
     },
+    displayDocumentationPrompt: false,
   },
   messages: {
     belowThreshold:
@@ -44,8 +45,9 @@ const defaultConfig = {
     )} use ${chalk.yellow(
       "`npm run test:updateCoverageExceptions`",
     )} to update the coverage threshold for these files.`,
-    // Override this message with a custom documentation prompt.
-    documentationPrompt: undefined,
+    documentationPrompt: `For more information on addressing coverage slips, see ${chalk.yellow(
+      "https://example.com/docs/coverage",
+    )}`,
   },
 };
 

--- a/src/coverageUtilities.js
+++ b/src/coverageUtilities.js
@@ -93,6 +93,11 @@ function logViolations(
   if (details) {
     infoTableData.push(["", `\n${details}`]);
   }
+
+  if (config.messages.documentationPrompt) {
+    infoTableData.push(["", `\n${config.messages.documentationPrompt}`]);
+  }
+
   // eslint-disable-next-line no-console
   console.log(
     table(infoTableData, {

--- a/src/coverageUtilities.js
+++ b/src/coverageUtilities.js
@@ -94,7 +94,7 @@ function logViolations(
     infoTableData.push(["", `\n${details}`]);
   }
 
-  if (config.messages.documentationPrompt) {
+  if (config.output.displayDocumentationPrompt) {
     infoTableData.push(["", `\n${config.messages.documentationPrompt}`]);
   }
 


### PR DESCRIPTION
Allow for the tooling to provide a documentation prompt to assist devs further.

<img width="1275" alt="Screenshot 2024-01-05 at 1 27 45 PM" src="https://github.com/GetJobber/jest-a-coverage-slip-detector/assets/128422973/f41a1ad3-87b4-4330-b5b3-a33f5e1564dd">
