### PR TITLE
feat: make messages overridable individually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.1.5",
+        "lodash": "^4.17.21",
         "minimatch": "^5.1.0",
         "table": "^6.8.0"
       },
@@ -890,6 +891,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -1951,6 +1957,11 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.5",
+    "lodash": "^4.17.21",
     "minimatch": "^5.1.0",
     "table": "^6.8.0"
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const chalk = require("chalk");
+const merge = require("lodash/merge");
 
 const CONFIG_DIR = ".jest-a-coverage-slip-detector";
 const CONFIG_FILE = "config.json";
@@ -53,7 +54,7 @@ function loadConfig() {
     return defaultConfig;
   }
 
-  return { ...defaultConfig, ...require(configPath) };
+  return merge(defaultConfig, require(configPath));
 }
 exports.loadConfig = loadConfig;
 


### PR DESCRIPTION
I wanted the ability to override a single message without having to specify all of them in the config file so I just added a deep merge in `loadConfig`.

I was torn between lodash or other libs to do the deep merge itself but lodash is a handy collection of utilities so that's what I went with.