### PR TITLE
fix: Update bin path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "jest",
     "ratchet"
   ],
-  "bin": "./bin/jest-a-coverage-slip-detector",
+  "bin": {
+    "jest-a-coverage-slip-detector": "bin/jest-a-coverage-slip-detector"
+  },
   "files": [
     "bin/*",
     "src/*.js",


### PR DESCRIPTION
While publishing, I noticed the following warnings:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "bin" was converted to an object
npm WARN publish "bin[@jobber/jest-a-coverage-slip-detector]" was renamed to "bin[jest-a-coverage-slip-detector]"
npm WARN publish "bin[jest-a-coverage-slip-detector]" script name was cleaned
```

This PR is the result of running `npm pkg fix`